### PR TITLE
Fix import from JSON in Python 2.7

### DIFF
--- a/ipython_genutils/importstring.py
+++ b/ipython_genutils/importstring.py
@@ -28,7 +28,7 @@ def import_item(name):
     if len(parts) == 2:
         # called with 'foo.bar....'
         package, obj = parts
-        module = __import__(package, fromlist=[obj])
+        module = __import__(package, fromlist=[str(obj)])
         try:
             pak = getattr(module, obj)
         except AttributeError:


### PR DESCRIPTION
Seems Python 2.7 does not like to be fed unicode for `__import__`:
http://stackoverflow.com/questions/27477880/portable-code-import-parameter-string-type-between-python-2-and-python-3

This is needed to allow loading additional pre/postprocessors from a JSON config file:
https://github.com/jupyter/nbconvert/issues/362
