### PR TITLE
Omit missing directories from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,18 +2,6 @@ include COPYING.md
 include CONTRIBUTING.md
 include README.md
 
-# Documentation
-graft docs
-exclude docs/\#*
-
-# Examples
-graft examples
-
-# docs subdirs we want to skip
-prune docs/build
-prune docs/gh-pages
-prune docs/dist
-
 # Patterns to exclude from any directory
 global-exclude *~
 global-exclude *.pyc


### PR DESCRIPTION
Some combinations of python and setuptools (e.g. 3.4.6 + 32.1.0) trace with `FileNotFoundError` on a graft with a missing directory.